### PR TITLE
flutter に表示するAPIのレスポンスを画面遷移のたびに更新する用に修正.

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -30,6 +30,7 @@ class TakePictureScreen extends StatefulWidget {
   TakePictureScreenState createState() => TakePictureScreenState();
 }
 
+// TODO: アプリのライフサイクル変更時にカメラコントローラの状態を処理することを検討する
 class TakePictureScreenState extends State<TakePictureScreen> with WidgetsBindingObserver {
   late CameraController _controller;
   late Future<void> _initializeControllerFuture;


### PR DESCRIPTION
## Sourcery による概要

カメラ画面がアクティブまたは可視状態になるたびに、保存された画像の表示APIレスポンスを更新

改善点:
- アプリのライフサイクルを監視し、アプリが再開されたときに更新されたAPIデータを取得
- プレビューからカメラ画面に戻った際にAPIの更新を呼び出す
- メモリリークを防ぐため、ウィジェット破棄時にライフサイクルオブザーバーの登録を解除

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refresh the displayed API response for saved images each time the camera screen becomes active or visible

Enhancements:
- Observe app lifecycle and fetch updated API data when the app is resumed
- Invoke API refresh upon returning to the camera screen from the preview
- Unregister the lifecycle observer during widget disposal to prevent leaks

</details>